### PR TITLE
Added product gallery fallback option

### DIFF
--- a/modules/woocommerce/tags/product-gallery.php
+++ b/modules/woocommerce/tags/product-gallery.php
@@ -8,6 +8,7 @@
 namespace MASElementor\Modules\Woocommerce\Tags;
 
 use MASElementor\Modules\Woocommerce\Module;
+use Elementor\Controls_Manager;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -59,12 +60,34 @@ class Product_Gallery extends Base_Data_Tag {
 
 		$attachment_ids = $product->get_gallery_image_ids();
 
-		foreach ( $attachment_ids as $attachment_id ) {
-			$value[] = array(
-				'id' => $attachment_id,
-			);
+		if ( $attachment_ids ) {
+			foreach ( $attachment_ids as $attachment_id ) {
+				$value[] = array(
+					'id' => $attachment_id,
+				);
+			}
+		} else {
+			$fall_back = $this->get_settings( 'mas-fallback' );
+			if ( ! empty( $fall_back['id'] ) ) {
+				$value[] = array(
+					'id' => $fall_back['id'],
+				);
+			}
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Register control.
+	 */
+	protected function register_controls() {
+		$this->add_control(
+			'mas-fallback',
+			array(
+				'label' => esc_html__( 'Fallback', 'mas-elementor' ),
+				'type'  => Controls_Manager::MEDIA,
+			)
+		);
 	}
 }

--- a/modules/woocommerce/widgets/products-base.php
+++ b/modules/woocommerce/widgets/products-base.php
@@ -96,6 +96,18 @@ abstract class Products_Base extends Base_Widget {
 			)
 		);
 
+		$this->add_responsive_control(
+			'loop_product_width',
+			array(
+				'label'      => __( 'Product Width', 'mas-elementor' ),
+				'type'       => Controls_Manager::SLIDER,
+				'size_units' => array( 'px', '%', 'em', 'rem', 'vh', 'custom' ),
+				'selectors'  => array(
+					'{{WRAPPER}} .mas-product,{{WRAPPER}} .mas-product [data-elementor-type="mas-post"]' => 'width: {{SIZE}}{{UNIT}} !important',
+				),
+			)
+		);
+
 		$this->end_controls_section();
 
 		$this->start_controls_section(


### PR DESCRIPTION
### Added fallback image option for product gallery

### Steps to test

- [x] Add a product widget in the page
- [x] Navigate to Saved Templates > Mas Post, and create one mas-post.
- [x] In Mas Post add a gallery widget and select product gallery in dynamic tag.
- [x] Upload the image in fallback option.
- [x] Navigate to the product widget in the page and select the mas-post you created in products widgets.

![image](https://github.com/madrasthemes/mas-elementor/assets/86230293/8986acfa-e600-429b-8c66-a10516688f88)

- [ ] Check the products in which the images are not uploaded should display fallback image as placeholder image


![image](https://github.com/madrasthemes/mas-elementor/assets/86230293/f1071525-08a9-4ebc-9fbb-c8f5a8af9a7c)
