### PR TITLE
Product carousel options

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -18,3 +18,21 @@
 .mas-carousel-short-description .woocommerce-product-details__short-description ul{
 	padding-left: 0px;
 }
+
+.elementor-widget-mas-woocommerce-products .mas-product .elementor-widget-image-carousel .swiper-slide {
+	width: 100% !important;
+	box-sizing: border-box;
+}
+
+.elementor-widget-mas-woocommerce-products .mas-product .elementor-widget-image-carousel .swiper-pagination-bullet-active {
+		width: 30px !important;
+    border-radius: 3px;
+}
+
+.mas-swiper-overflow {
+	overflow: hidden;
+}
+
+.mas-swiper-overflow .swiper {
+	overflow: visible;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -36,3 +36,7 @@
 .mas-swiper-overflow .swiper {
 	overflow: visible;
 }
+
+.mas-swiper-inactive-arrows-hide .swiper-button-disabled {
+      display: none;
+}

--- a/modules/woocommerce/widgets/products.php
+++ b/modules/woocommerce/widgets/products.php
@@ -928,6 +928,23 @@ class Products extends Products_Base {
 			)
 		);
 
+		$this->add_control(
+			'hide_inactive_arrows',
+			array(
+				'type'      => Controls_Manager::SWITCHER,
+				'label'     => esc_html__( 'Hide Inactive Arrow', 'mas-elementor' ),
+				'default'   => 'no',
+				'label_off' => esc_html__( 'Hide', 'mas-elementor' ),
+				'label_on'  => esc_html__( 'Show', 'mas-elementor' ),
+				'condition' => array(
+					'enable_carousel'     => 'yes',
+					'show_custom_arrows!' => 'yes',
+				),
+				'return_value' => 'hide',
+				'prefix_class' => 'mas-swiper-inactive-arrows-',
+			)
+		);
+
 		$this->add_responsive_control(
 			'hide_responsive_arrows',
 			array(

--- a/modules/woocommerce/widgets/products.php
+++ b/modules/woocommerce/widgets/products.php
@@ -936,8 +936,9 @@ class Products extends Products_Base {
 				'default'   => 'no',
 				'label_off' => esc_html__( 'Hide', 'mas-elementor' ),
 				'label_on'  => esc_html__( 'Show', 'mas-elementor' ),
-				'condition' => array(
+				'condition'    => array(
 					'enable_carousel'     => 'yes',
+					'show_arrows'         => 'yes',
 					'show_custom_arrows!' => 'yes',
 				),
 				'return_value' => 'hide',


### PR DESCRIPTION
Carousel Options #82

### Steps to test 

1. Checkout to this branch and add product widget.
2. Enable carousel in product widget, and enable arrows and the new option added refer in below image.
3. The inactive arrow should be hidden like in 2nd image.

![image](https://github.com/madrasthemes/mas-elementor/assets/86230293/9e13a228-63dc-4fdd-9b71-9058ceeddb4e)

![image](https://github.com/madrasthemes/mas-elementor/assets/86230293/7f065a5d-3f11-47d1-8fbc-0c59bb7cca64)



