### PR TITLE
Feature - sale percentage tag

### DIFF
--- a/modules/carousel-attributes/traits/pagination-trait.php
+++ b/modules/carousel-attributes/traits/pagination-trait.php
@@ -662,6 +662,75 @@ trait Pagination_Trait {
 					)
 				);
 
+				$element->add_responsive_control(
+					'swiper_pagination_z_index',
+					array(
+						'label'     => esc_html__( 'Z-Index', 'mas-elementor' ),
+						'type'      => Controls_Manager::NUMBER,
+						'selectors'  => array(
+							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination' => 'z-index: {{VALUE}};',
+						),
+					)
+				);
+
+				$element->add_responsive_control(
+					'swiper_pagination_spacing_top',
+					array(
+						'label'      => esc_html__( 'Top Spacing', 'mas-elementor' ),
+						'type'       => Controls_Manager::SLIDER,
+						'default'    => array(
+							'size' => 0,
+						),
+						'size_units' => array( 'px', '%', 'rem' ),
+						'range'      => array(
+							'%' => array(
+								'min' => 0,
+								'max' => 100,
+							),
+						),
+						'selectors'  => array(
+							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination-horizontal' => 'bottom: 0px !important;',
+							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination.swiper-pagination-bullets' => 'margin-top: {{SIZE}}{{UNIT}} !important;',
+							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination-progressbar.swiper-pagination-horizontal' => 'margin-top: {{SIZE}}{{UNIT}} !important;',
+							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination.swiper-pagination-fraction' => 'margin-top: {{SIZE}}{{UNIT}} !important;',
+						),
+						'condition'  => array(
+							'enable_carousel' => 'yes',
+							'show_pagination' => 'yes',
+							'mas_swiper_pagination_position' => 'relative',
+						),
+					)
+				);
+
+				$element->add_responsive_control(
+					'pagination_spacing_bottom',
+					array(
+						'label'      => esc_html__( 'Bottom Spacing', 'mas-elementor' ),
+						'type'       => Controls_Manager::SLIDER,
+						'default'    => array(
+							'size' => 0,
+						),
+						'size_units' => array( 'px', '%', 'rem' ),
+						'range'      => array(
+							'%' => array(
+								'min' => 0,
+								'max' => 100,
+							),
+						),
+						'selectors'  => array(
+							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination-horizontal' => 'bottom: 0px !important;',
+							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination.swiper-pagination-bullets' => 'margin-bottom: {{SIZE}}{{UNIT}} !important;',
+							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination-progressbar.swiper-pagination-horizontal' => 'margin-bottom: {{SIZE}}{{UNIT}} !important;',
+							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination.swiper-pagination-fraction' => 'margin-bottom: {{SIZE}}{{UNIT}} !important;',
+						),
+						'condition'  => array(
+							'enable_carousel' => 'yes',
+							'show_pagination' => 'yes',
+							'mas_swiper_pagination_position' => 'relative',
+						),
+					)
+				);
+
 				$element->add_control(
 					'mas_swiper_pagination_position',
 					array(
@@ -817,64 +886,6 @@ trait Pagination_Trait {
 							'enable_carousel'            => 'yes',
 							'show_pagination'            => 'yes',
 							'mas_swiper_pagination_position' => 'absolute',
-						),
-					)
-				);
-
-				$element->add_control(
-					'swiper_pagination_spacing_top',
-					array(
-						'label'      => esc_html__( 'Top Spacing', 'mas-elementor' ),
-						'type'       => Controls_Manager::SLIDER,
-						'default'    => array(
-							'size' => 0,
-						),
-						'size_units' => array( 'px', '%', 'rem' ),
-						'range'      => array(
-							'%' => array(
-								'min' => 0,
-								'max' => 100,
-							),
-						),
-						'selectors'  => array(
-							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination-horizontal' => 'bottom: 0px !important;',
-							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination.swiper-pagination-bullets' => 'margin-top: {{SIZE}}{{UNIT}} !important;',
-							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination-progressbar.swiper-pagination-horizontal' => 'margin-top: {{SIZE}}{{UNIT}} !important;',
-							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination.swiper-pagination-fraction' => 'margin-top: {{SIZE}}{{UNIT}} !important;',
-						),
-						'condition'  => array(
-							'enable_carousel' => 'yes',
-							'show_pagination' => 'yes',
-							'mas_swiper_pagination_position' => 'relative',
-						),
-					)
-				);
-
-				$element->add_control(
-					'pagination_spacing_bottom',
-					array(
-						'label'      => esc_html__( 'Bottom Spacing', 'mas-elementor' ),
-						'type'       => Controls_Manager::SLIDER,
-						'default'    => array(
-							'size' => 0,
-						),
-						'size_units' => array( 'px', '%', 'rem' ),
-						'range'      => array(
-							'%' => array(
-								'min' => 0,
-								'max' => 100,
-							),
-						),
-						'selectors'  => array(
-							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination-horizontal' => 'bottom: 0px !important;',
-							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination.swiper-pagination-bullets' => 'margin-bottom: {{SIZE}}{{UNIT}} !important;',
-							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination-progressbar.swiper-pagination-horizontal' => 'margin-bottom: {{SIZE}}{{UNIT}} !important;',
-							'{{WRAPPER}} ' . $args['concat'] . ' .swiper-pagination.swiper-pagination-fraction' => 'margin-bottom: {{SIZE}}{{UNIT}} !important;',
-						),
-						'condition'  => array(
-							'enable_carousel' => 'yes',
-							'show_pagination' => 'yes',
-							'mas_swiper_pagination_position' => 'relative',
 						),
 					)
 				);

--- a/modules/woocommerce/module.php
+++ b/modules/woocommerce/module.php
@@ -159,6 +159,7 @@ class Module extends Module_Base {
 			'Cart_Button_Text',
 			'Product_Content',
 			'Product_Sold_Count',
+			'Product_Onsale_Percentage',
 		);
 
 		$module = Plugin::elementor()->dynamic_tags;

--- a/modules/woocommerce/tags/product-onsale-percentage.php
+++ b/modules/woocommerce/tags/product-onsale-percentage.php
@@ -135,6 +135,10 @@ class Product_Onsale_Percentage extends Base_Tag {
 			)
 		);
 
+		if ( empty( $sale_price ) ) {
+			return;
+		}
+
 		if ( 'amount' === $this->get_settings( 'output' ) ) {
 
 			$savings = wc_price( $regular_price - $sale_price );

--- a/modules/woocommerce/tags/product-onsale-percentage.php
+++ b/modules/woocommerce/tags/product-onsale-percentage.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Product_Onsale_Percentage.
+ *
+ * @package MASElementor\Modules\Woocommerce\Tags
+ */
+
+namespace MASElementor\Modules\Woocommerce\Tags;
+
+use Elementor\Controls_Manager;
+use MASElementor\Modules\Woocommerce\Tags\Traits\Tag_Product_Id;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Product Sale.
+ */
+class Product_Onsale_Percentage extends Base_Tag {
+	/**
+	 * Get name.
+	 */
+	public function get_name() {
+		return 'mas-woocommerce-product-onsale-percentage-tag';
+	}
+
+	/**
+	 * Get Title.
+	 */
+	public function get_title() {
+		return esc_html__( 'OnSale Percentage', 'mas-elementor' );
+	}
+
+	/**
+	 * Register Controls.
+	 */
+	protected function register_controls() {
+		$this->add_control(
+			'output',
+			array(
+				'label'   => esc_html__( 'Output Format', 'mas-elementor' ),
+				'type'    => Controls_Manager::SELECT,
+				'options' => array(
+					'amount'     => esc_html__( 'Amount', 'mas-elementor' ),
+					'percentage' => esc_html__( 'Percentage', 'mas-elementor' ),
+				),
+				'default' => 'percentage',
+			)
+		);
+
+		$this->add_control(
+			'text_prefix',
+			array(
+				'label'   => esc_html__( 'Prefix', 'mas-elementor' ),
+				'type'    => Controls_Manager::TEXT,
+				'default' => esc_html__( '-', 'mas-elementor' ),
+			)
+		);
+
+		$this->add_control(
+			'text_suffix',
+			array(
+				'label'   => esc_html__( 'Suffix', 'mas-elementor' ),
+				'type'    => Controls_Manager::TEXT,
+				'default' => esc_html__( '%', 'mas-elementor' ),
+			)
+		);
+
+		$this->add_product_id_control();
+	}
+
+	/**
+	 * Render.
+	 */
+	public function render() {
+		$product = wc_get_product( $this->get_settings( 'product_id' ) );
+		if ( ! $product ) {
+			return;
+		}
+
+		if ( $product->is_type( 'variable' ) ) {
+			$var_regular_price    = array();
+			$var_sale_price       = array();
+			$var_diff_price       = array();
+			$available_variations = $product->get_available_variations();
+			foreach ( $available_variations as $key => $available_variation ) {
+				$variation_id     = $available_variation['variation_id']; // Getting the variable id of just the 1st product. You can loop $available_variations to get info about each variation.
+				$variable_product = new WC_Product_Variation( $variation_id );
+
+				$variable_product_regular_price = $variable_product->get_regular_price();
+				$variable_product_sale_price    = $variable_product->get_sale_price();
+
+				if ( ! empty( $variable_product_regular_price ) ) {
+					$var_regular_price[] = $variable_product_regular_price;
+				} else {
+					$var_regular_price[] = 0;
+				}
+				if ( ! empty( $variable_product_sale_price ) ) {
+					$var_sale_price[] = $variable_product_sale_price;
+				} else {
+					$var_sale_price[] = 0;
+				}
+			}
+
+			foreach ( $var_regular_price as $key => $reg_price ) {
+				if ( isset( $var_sale_price[ $key ] ) && 0 !== $var_sale_price[ $key ] ) {
+					$var_diff_price[] = $reg_price - $var_sale_price[ $key ];
+				} else {
+					$var_diff_price[] = 0;
+				}
+			}
+
+			$best_key = array_search( max( $var_diff_price ), $var_diff_price );
+
+			$regular_price = $var_regular_price[ $best_key ];
+			$sale_price    = $var_sale_price[ $best_key ];
+		} else {
+			$regular_price = $product->get_regular_price();
+			$sale_price    = $product->get_sale_price();
+		}
+
+		$regular_price = wc_get_price_to_display(
+			$product,
+			array(
+				'qty'   => 1,
+				'price' => $regular_price,
+			)
+		);
+		$sale_price    = wc_get_price_to_display(
+			$product,
+			array(
+				'qty'   => 1,
+				'price' => $sale_price,
+			)
+		);
+
+		if ( 'amount' === $this->get_settings( 'output' ) ) {
+
+			$savings = wc_price( $regular_price - $sale_price );
+
+		} elseif ( 'percentage' === $this->get_settings( 'output' ) ) {
+
+			$savings = round( ( ( $regular_price - $sale_price ) / $regular_price ) * 100 );
+		}
+
+		if ( ! empty( $savings ) ) {
+			$savings = $this->get_settings( 'text_prefix' ) . $savings . $this->get_settings( 'text_suffix' );
+			echo wp_kses_post( $savings );
+		}
+
+	}
+}

--- a/modules/woocommerce/tags/product-onsale-percentage.php
+++ b/modules/woocommerce/tags/product-onsale-percentage.php
@@ -111,7 +111,7 @@ class Product_Onsale_Percentage extends Base_Tag {
 				}
 			}
 
-			$best_key = array_search( max( $var_diff_price ), $var_diff_price );
+			$best_key = array_search( max( $var_diff_price ), $var_diff_price, true );
 
 			$regular_price = $var_regular_price[ $best_key ];
 			$sale_price    = $var_sale_price[ $best_key ];


### PR DESCRIPTION
### Steps to test the feature

1.  Add products widget in  a page.
2. Add a mas-post in Saved Templates > Mas Post.
3. Add a button or  heading widget and use **Onsale percentage** tag in dynamic tags like first image.
4. Select that mas-post for products widget you created in a page.
5. When onsale products are listed it will display the onsale percentage as button text like second image.


1. 
![image](https://github.com/madrasthemes/mas-elementor/assets/86230293/108feb1b-e968-44a4-8080-92dd30232f76)

2. 
![image](https://github.com/madrasthemes/mas-elementor/assets/86230293/ecfcd70e-faae-4a51-a7bd-d3a0ce6d6cb8)

