### PR TITLE
fix product price sale flex

### DIFF
--- a/modules/woocommerce/widgets/product-price.php
+++ b/modules/woocommerce/widgets/product-price.php
@@ -245,7 +245,7 @@ class Product_Price extends Base_Widget {
 
 		$start   = is_rtl() ? 'right' : 'left';
 		$end     = is_rtl() ? 'left' : 'right';
-		$wrapper = '{{WRAPPER}} .price:has(ins)';
+		$wrapper = '{{WRAPPER}} .price:has(ins), {{WRAPPER}} .electro-price:has(ins)';
 
 		$this->add_responsive_control(
 			'enable_flex',


### PR DESCRIPTION
### Steps to test the feature

1.  Add products widget in  a page.
2. Add a mas-post in Saved Templates > Mas Post.
3. Add a product price widget and check flex option like below image.
4. Select that mas-post for products widget you created in a page.
5. When onsale products are listed it will display the onsale price and regular price with selected flex options 


![image](https://github.com/madrasthemes/mas-elementor/assets/86230293/23e10079-77b0-481d-b045-8e984a0f4414)
