### PR TITLE
Fix - Add to compare

### DIFF
--- a/assets/js/add-to-compare/add-to-compare.js
+++ b/assets/js/add-to-compare/add-to-compare.js
@@ -6,13 +6,13 @@
 ( function( $, window ) {
     'use strict';
 
-    $(document).on('click', '.add-to-compare-link:not(.added)', function (e) {
+    $(document).on('click', '.elementor-widget-mas-add-to-compare .add-to-compare-link:not(.added)', function (e) {
 
         e.preventDefault();
     
         var button = $(this),
             data = {
-                _yitnonce_ajax: yith_woocompare.nonceadd,
+                security: yith_woocompare.add_nonce,
                 action: yith_woocompare.actionadd,
                 id: button.data('product_id'),
                 context: 'frontend'
@@ -51,6 +51,9 @@
     
                 // add the product in the widget
                 widget_list.html(response.widget_table);
+
+                if ( yith_woocompare.auto_open == 'yes')
+                    $('body').trigger( 'yith_woocompare_open_popup', { response: response.table_url, button: button } );
             }
         });
     });

--- a/modules/woocommerce/module.php
+++ b/modules/woocommerce/module.php
@@ -98,9 +98,8 @@ class Module extends Module_Base {
 		if ( function_exists( 'electro_header_mini_cart_icon' ) ) {
 			$widgets[] = 'Header_Cart';
 		}
-		if ( function_exists( 'is_yith_woocompare_activated' ) && is_yith_woocompare_activated() ) {
-			$widgets[] = 'Add_To_Compare';
-		}
+
+		$widgets[] = 'Add_To_Compare';
 
 		return $widgets;
 	}


### PR DESCRIPTION
### Steps to check

1. Activate yith compare plugin
2. Add products widgets in a page.
3. Create a mas-post for that products widget and insert add-to-compare widget in mas-post.
4. Go to the page you added products widget and view that page.
5. Click on compare button and check if the popup shows and after that added is changed as text with your assigned url.
