### PR TITLE
Fix - Carousel Arrows

### DIFF
--- a/modules/carousel-attributes/traits/button-widget-trait.php
+++ b/modules/carousel-attributes/traits/button-widget-trait.php
@@ -324,7 +324,7 @@ trait Button_Widget_Trait {
 			Group_Control_Text_Shadow::get_type(),
 			array(
 				'name'      => 'swiper_arrow_text_shadow',
-				'selector'  => '{{WRAPPER}} .elementor-button-link',
+				'selector'  => '{{WRAPPER}} ' . $args['button_concat'] . ' .mas-swiper-arrows .elementor-button-link',
 				'condition' => $args['section_condition'],
 			)
 		);
@@ -515,7 +515,7 @@ trait Button_Widget_Trait {
 			Group_Control_Box_Shadow::get_type(),
 			array(
 				'name'      => 'swiper_arrow_button_box_shadow',
-				'selector'  => '{{WRAPPER}} .elementor-button-link',
+				'selector'  => '{{WRAPPER}} ' . $args['button_concat'] . ' .mas-swiper-arrows .elementor-button-link',
 				'condition' => $args['section_condition'],
 			)
 		);


### PR DESCRIPTION
### steps to check the issue

1. Create a product with mas-post,
2. when using box-shadow the shadow should apply only for carousel arrows

![image](https://github.com/madrasthemes/mas-elementor/assets/86230293/0e98bd33-e17a-438f-ab34-a0f340c9272c)


![image](https://github.com/madrasthemes/mas-elementor/assets/86230293/2b1c8078-415e-4677-823c-1ebd32de9306)
