### PR TITLE
Added icon position control in mas-nav-tabs

### DIFF
--- a/mas-elementor.php
+++ b/mas-elementor.php
@@ -13,7 +13,7 @@ use Elementor\plugin;
  * Plugin URI: https://github.com/madrasthemes/mas-elementor
  * Author: MadrasThemes
  * Version: 1.1.4
- * Elementor tested up to: 3.19.0
+ * Elementor tested up to: 3.24.0
  * Author URI: https://madrasthemes.com/
  *
  * Text Domain: mas-elementor
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'MAS_ELEMENTOR_VERSION', '1.1' );
+define( 'MAS_ELEMENTOR_VERSION', '1.1.4' );
 
 define( 'MAS_ELEMENTOR__FILE__', __FILE__ );
 define( 'MAS_ELEMENTOR_BASE', plugin_basename( MAS_ELEMENTOR__FILE__ ) );

--- a/modules/mas-nav-tabs/widgets/mas-nav-tabs.php
+++ b/modules/mas-nav-tabs/widgets/mas-nav-tabs.php
@@ -921,6 +921,35 @@ class Mas_Nav_Tabs extends Base_Widget {
 			)
 		);
 
+		$start = is_rtl() ? 'right' : 'left';
+		$end   = is_rtl() ? 'left' : 'right';
+
+		$this->add_control(
+			'tab_icon_align',
+			array(
+				'label'                => esc_html__( 'Icon Position', 'mas-elementor' ),
+				'type'                 => Controls_Manager::CHOOSE,
+				'default'              => is_rtl() ? 'row-reverse' : 'row',
+				'options'              => array(
+					'row'         => array(
+						'title' => esc_html__( 'Start', 'mas-elementor' ),
+						'icon'  => "eicon-h-align-{$start}",
+					),
+					'row-reverse' => array(
+						'title' => esc_html__( 'End', 'mas-elementor' ),
+						'icon'  => "eicon-h-align-{$end}",
+					),
+				),
+				'selectors_dictionary' => array(
+					'left'  => is_rtl() ? 'row-reverse' : 'row',
+					'right' => is_rtl() ? 'row' : 'row-reverse',
+				),
+				'selectors'            => array(
+					'{{WRAPPER}} .mas-tab-flex' => 'flex-direction: {{VALUE}};',
+				),
+			)
+		);
+
 		$this->add_control(
 			'icon_color',
 			array(

--- a/modules/mas-nav-tabs/widgets/mas-nav-tabs.php
+++ b/modules/mas-nav-tabs/widgets/mas-nav-tabs.php
@@ -713,7 +713,7 @@ class Mas_Nav_Tabs extends Base_Widget {
 				'type'       => Controls_Manager::DIMENSIONS,
 				'size_units' => array( 'px', 'em', '%', 'rem' ),
 				'selectors'  => array(
-					'{{WRAPPER}} .mas-nav-link:hover' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+					'{{WRAPPER}} .mas-elementor-nav-tab .mas-nav-link:hover' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
 				),
 			)
 		);
@@ -726,7 +726,7 @@ class Mas_Nav_Tabs extends Base_Widget {
 				'type'       => Controls_Manager::DIMENSIONS,
 				'size_units' => array( 'px', 'em', '%', 'rem' ),
 				'selectors'  => array(
-					'{{WRAPPER}} .mas-nav-link:hover' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+					'{{WRAPPER}} .mas-elementor-nav-tab .mas-nav-link:hover' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
 				),
 			)
 		);
@@ -736,7 +736,7 @@ class Mas_Nav_Tabs extends Base_Widget {
 			Group_Control_Border::get_type(),
 			array(
 				'name'     => 'mas_nav_link_border_hover',
-				'selector' => '{{WRAPPER}} .mas-nav-link:hover',
+				'selector' => '{{WRAPPER}} .mas-elementor-nav-tab .mas-nav-link:hover',
 			)
 		);
 
@@ -748,7 +748,7 @@ class Mas_Nav_Tabs extends Base_Widget {
 				'type'       => Controls_Manager::DIMENSIONS,
 				'size_units' => array( 'px', '%', 'em' ),
 				'selectors'  => array(
-					'{{WRAPPER}} .mas-nav-link:hover' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+					'{{WRAPPER}} .mas-elementor-nav-tab .mas-nav-link:hover' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
 				),
 			)
 		);
@@ -758,7 +758,7 @@ class Mas_Nav_Tabs extends Base_Widget {
 			Group_Control_Box_Shadow::get_type(),
 			array(
 				'name'     => 'mas_nav_link_box_shadow_hover',
-				'selector' => '{{WRAPPER}} .mas-nav-link:hover',
+				'selector' => '{{WRAPPER}} .mas-elementor-nav-tab .mas-nav-link:hover',
 			)
 		);
 
@@ -769,7 +769,7 @@ class Mas_Nav_Tabs extends Base_Widget {
 				'label'     => esc_html__( 'Background Color', 'mas-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'selectors' => array(
-					'{{WRAPPER}} .mas-nav-link:hover' => 'background-color: {{VALUE}};',
+					'{{WRAPPER}} .mas-elementor-nav-tab .mas-nav-link:hover' => 'background-color: {{VALUE}};',
 				),
 			)
 		);
@@ -780,7 +780,7 @@ class Mas_Nav_Tabs extends Base_Widget {
 				'label'     => esc_html__( 'Title Color', 'mas-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'selectors' => array(
-					'{{WRAPPER}} .mas-nav-link:hover' => 'color: {{VALUE}};',
+					'{{WRAPPER}} .mas-elementor-nav-tab .mas-nav-link:hover' => 'color: {{VALUE}};',
 				),
 			)
 		);
@@ -789,7 +789,7 @@ class Mas_Nav_Tabs extends Base_Widget {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'anchor_typography_hover',
-				'selector' => '{{WRAPPER}} .mas-nav-link:hover',
+				'selector' => '{{WRAPPER}} .mas-elementor-nav-tab .mas-nav-link:hover',
 
 			)
 		);


### PR DESCRIPTION
### Steps to test

1. Add MAS Nav Tabs widget in a page and go to style tab.
2. Open Icon tab and check the icon position functionality. 

ref : 
![image](https://github.com/user-attachments/assets/3c03713e-ec27-478f-873f-b2dd9cba7108)
