### PR TITLE
Fixes offset Issue

### DIFF
--- a/modules/woocommerce/tags/product-image.php
+++ b/modules/woocommerce/tags/product-image.php
@@ -75,9 +75,14 @@ class Product_Image extends Base_Data_Tag {
 
 		$src = wp_get_attachment_image_src( $image_id, 'full' );
 
+		if ( ! is_array( $src ) || empty( $src[0] ) ) {
+		    return array();
+		}
+
 		return array(
-			'id'  => $image_id,
-			'url' => $src[0],
+		    'id'  => $image_id,
+		    'url' => $src[0],
 		);
+
 	}
 }


### PR DESCRIPTION
This PR fixes the error in Product Image tag 

Steps to reproduce the error

1. Remove the product image from the product 

2. Edit a page with Elementor

3. Add new MAS Post Template with image widget and choose product image in tags.

4. In the page editor add products widget and choose  created template

5. Save and view the page
