### PR TITLE
Fixes enqueued dependencies not registered warning

### DIFF
--- a/modules/column/module.php
+++ b/modules/column/module.php
@@ -47,7 +47,7 @@ class Module extends Module_Base {
 		add_action( 'elementor/element/column/section_advanced/before_section_end', array( $this, 'add_widget_wrap_controls' ) );
 		add_action( 'elementor/element/after_add_attributes', array( $this, 'modify_attributes' ), 20 );
 		add_filter( 'elementor/column/print_template', array( $this, 'print_template' ), 10, 2 );
-		add_action( 'elementor/frontend/before_enqueue_scripts', array( $this, 'register_frontend_scripts' ) );
+		add_action( 'elementor/frontend/before_register_scripts', array( $this, 'register_frontend_scripts' ) );
 	}
 
 	/**
@@ -183,7 +183,7 @@ class Module extends Module_Base {
 	 * Register frontend script.
 	 */
 	public function register_frontend_scripts() {
-		wp_enqueue_script(
+		wp_register_script(
 			'mas-scroll-script',
 			MAS_ELEMENTOR_ASSETS_URL . 'js/scrollspy/scroll.min.js',
 			array(),
@@ -191,7 +191,7 @@ class Module extends Module_Base {
 			true
 		);
 
-		wp_enqueue_script(
+		wp_register_script(
 			'scrollspy-init-script',
 			MAS_ELEMENTOR_ASSETS_URL . 'js/scrollspy/scroll-init.js',
 			array( 'mas-bootstrap-bundle' ),

--- a/modules/forms/module.php
+++ b/modules/forms/module.php
@@ -349,7 +349,7 @@ class Module extends Module_Base {
 		wp_register_script(
 			'forgot-password',
 			MAS_ELEMENTOR_MODULES_URL . 'forms/assets/js/forgot-password.js',
-			array( '' ),
+			array(),
 			MAS_ELEMENTOR_VERSION,
 			true
 		);

--- a/plugin.php
+++ b/plugin.php
@@ -189,16 +189,27 @@ class Plugin {
 	 */
 	public function enqueue_frontend_scripts() {
 		if ( ! wp_script_is( 'bootstrap-js', 'enqueued' ) ) {
-			wp_enqueue_script(
-				'mas-bootstrap-bundle',
-				MAS_ELEMENTOR_ASSETS_URL . 'js/bootstrap/bootstrap.bundle.min.js',
-				array(),
-				MAS_ELEMENTOR_VERSION,
-				true
-			);
+			wp_enqueue_script( 'mas-bootstrap-bundle' );
 		}
 
-		wp_enqueue_script(
+		wp_enqueue_script( 'mas-magnigy-popup' );
+		wp_enqueue_script( 'mas-popup-init' );
+		wp_enqueue_script( 'mas-collapse-script' );
+	}
+
+	/**
+	 * Register frontend scripts used by the plugin.
+	 */
+	public function register_frontend_scripts() {
+		wp_register_script(
+			'mas-bootstrap-bundle',
+			MAS_ELEMENTOR_ASSETS_URL . 'js/bootstrap/bootstrap.bundle.min.js',
+			array(),
+			MAS_ELEMENTOR_VERSION,
+			true
+		);
+
+		wp_register_script(
 			'mas-magnigy-popup',
 			MAS_ELEMENTOR_ASSETS_URL . 'js/popup/jquery.magnific-popup.min.js',
 			array(),
@@ -206,7 +217,7 @@ class Plugin {
 			true
 		);
 
-		wp_enqueue_script(
+		wp_register_script(
 			'mas-popup-init',
 			MAS_ELEMENTOR_ASSETS_URL . 'js/popup/popup-init.js',
 			array(),
@@ -214,7 +225,7 @@ class Plugin {
 			true
 		);
 
-		wp_enqueue_script(
+		wp_register_script(
 			'mas-collapse-script',
 			MAS_ELEMENTOR_ASSETS_URL . 'js/tabs/mas-button-toggle.js',
 			array(),
@@ -222,11 +233,6 @@ class Plugin {
 			true
 		);
 	}
-
-	/**
-	 * Register frontend scripts used by the plugin.
-	 */
-	public function register_frontend_scripts() {}
 
 	/**
 	 * Register preview scripts used by the plugin.


### PR DESCRIPTION
This PR fixes the strictly validates dependencies warnings added in WordPress 6.9.1